### PR TITLE
Report proper free space

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ if(process.platform == 'win32') {
     var Struct = require('ref-struct')
       , ArrayType = require('ref-array');
 
-    var fsblkcnt_t = ref.types.ulong
-      , fsfilcnt_t = ref.types.ulong
+    var fsblkcnt_t = (process.platform == 'darwin') ? ref.types.uint : ref.types.ulong
+      , fsfilcnt_t = (process.platform == 'darwin') ? ref.types.uint : ref.types.ulong
       , ulong = ref.types.ulong
       , char = ref.types.char;
 


### PR DESCRIPTION
statvfs.f_bfree is also expressed in terms of statvfs.f_frsize, so use the appropriate field to calculate free space
