### PR TITLE
Update to latest ffi and ref packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Get total diskspace and free diskspace using bindings around platform specific calls.",
   "main": "index.js",
   "dependencies": {
-    "ffi": "~1.2.6",
-    "ref": "~0.1.3",
-    "ref-struct": "0.0.5",
-    "ref-array": "0.0.3"
+    "ffi": "~1.3.0",
+    "ref": "~1.0.1",
+    "ref-struct": "~1.0.1",
+    "ref-array": "~1.1.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This adds support for node.js v0.12.x and io.js >= v1.1.0.