### PR TITLE
Implemented `available` - disk space available to the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ $ npm install diskusage
 Usage
 --------
 
-The module exposes a single function, `check`. It takes a path/mount point as the first argument and a callback as the second. The callback takes two arguments `err` and `info`. `err` will be non-zero if somethine went wrong. `info` contains two members: `free` and `total` both of which contain the amount of free space and total used space in bytes.
+The module exposes a single function, `check`. It takes a path/mount point as the first argument and a callback as the second. The callback takes two arguments `err` and `info`. `err` will be non-zero if somethine went wrong. `info` contains three members: `available`, `free` and `total` in bytes.
+
+- `available`: Disk space available to the current user (i.e. Linux reserves 5% for root)
+- `free`: Disk space physically free
+- `total`: Total disk space (free + used)
 
 ### Linux Note
 `statvfs` under Linux also counts for mount points mounted under the root mount. For example using the mount point `/` as the first parameter would also account for `/dev`, `/run`, etc. in the free and total spaces.
@@ -29,6 +33,7 @@ var disk = require('diskusage');
 
 // get disk usage. Takes path as first parameter
 disk.check('c:', function(err, info) {
+	console.log(info.available);
 	console.log(info.free);
 	console.log(info.total);
 });
@@ -40,6 +45,7 @@ var disk = require('diskusage');
 
 // get disk usage. Takes mount point as first parameter
 disk.check('/', function(err, info) {
+	console.log(info.available);
 	console.log(info.free);
 	console.log(info.total);
 });

--- a/index.js
+++ b/index.js
@@ -8,13 +8,15 @@ if(process.platform == 'win32') {
     })
 
     exports.check = function(drive, callback) {
-        var freeBytesPtr = ref.alloc(ref.types.uint64)
+        var availableBytesPtr = ref.alloc(ref.types.uint64)
+          , freeBytesPtr = ref.alloc(ref.types.uint64)
           , totalBytesPtr = ref.alloc(ref.types.uint64);
-        var returnCode = DiskApi.GetDiskFreeSpaceExA(drive, freeBytesPtr, totalBytesPtr, ref.NULL_POINTER);
+        var returnCode = DiskApi.GetDiskFreeSpaceExA(drive, availableBytesPtr, totalBytesPtr, freeBytesPtr);
         if(!returnCode) {
             callback(returnCode, undefined);
         } else {
             callback(undefined, { 
+                available: availableBytesPtr.deref(),
                 free: freeBytesPtr.deref(),
                 total: totalBytesPtr.deref()
             });
@@ -63,6 +65,7 @@ if(process.platform == 'win32') {
             callback(returnCode, undefined);
         } else {
             callback(undefined, { 
+                available: statvfs.f_bavail * statvfs.f_frsize,
                 free: statvfs.f_bfree * statvfs.f_frsize,
                 total: statvfs.f_blocks * statvfs.f_frsize
             });


### PR DESCRIPTION
Solves the problem described in issue #3 (i.e. Linux reserves 5% disk space for root).

I added a new field "available" instead of changing the implementation of "free" - because both use-cases may be needed.

I also changed the implementation on Windows - It's still not exactly the same an on UNIX as there is no "total" bytes field - only "total bytes available to current user" - but at least "free" and "available" matches the UNIX implementation now.