### PR TITLE
ReferenceError: os is not defined in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Examples
 
 ``` js
 const disk = require('diskusage');
+const os = require('os');
 
 let path = os.platform() === 'win32' ? 'c:' : '/';
 


### PR DESCRIPTION
Got a 'ReferenceError: os is not defined' error when running example. Adding this line resolved it for me.
Note: I'm using v6.10.3 of nodejs.