### PR TITLE
Remove dependency on GLIBCXX_3.4.21

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
         'src/main.cpp',
         'src/diskusage.h',
       ],
-      'cflags_cc' : [
+      'cflags' : [
         '-std=c++11',
         '-D_GLIBCXX_USE_CXX11_ABI=0'
       ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,7 @@
         'src/diskusage.h',
       ],
       'cflags_cc' : [
+        '-std=c++11',
         '-D_GLIBCXX_USE_CXX11_ABI=0'
       ],
       'conditions': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,8 +7,8 @@
         'src/main.cpp',
         'src/diskusage.h',
       ],
-      'cflags' : [
-        '-std=c++11'
+      'cflags_cc' : [
+        '-D_GLIBCXX_USE_CXX11_ABI=0'
       ],
       'conditions': [
         ['OS=="win"', {


### PR DESCRIPTION
This will allow to use the module with older libstd.so