### PR TITLE
Feature - Add promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Usage
 
 The module exposes two functions. `check` takes a path/mount point as the first argument and a callback as the second. The callback takes two arguments `err` and `info`. `err` will be an `Error` if something went wrong. `info` contains three members: `available`, `free` and `total` in bytes.
 
+If no callback is supplied `check` will instead return a `Promise<DiskUsage>` that you can await.
+
 - `available`: Disk space available to the current user (i.e. Linux reserves 5% for root)
 - `free`: Disk space physically free
 - `total`: Total disk space (free + used)
@@ -32,24 +34,43 @@ const os = require('os');
 
 let path = os.platform() === 'win32' ? 'c:' : '/';
 
+// Callbacks
 disk.check(path, function(err, info) {
-	if (err) {
-		console.log(err);
-	} else {
-		console.log(info.available);
-		console.log(info.free);
-		console.log(info.total);
-	}
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(info.available);
+    console.log(info.free);
+    console.log(info.total);
+  }
 });
 
+// Promise
+async function getFreeSpace(path) {
+  try {
+    const { free } = await disk.check(path);
+    console.log(`Free space: ${free}`);
+    return free
+  } catch (err) {
+    console.error(err)
+    return 0
+  }
+}
+
+// Or without using async/await
+disk.check(path)
+  .then(info => console.log(`free: ${info.free}`))
+  .catch(err => console.error(err))
+
+// Synchronous
 try {
-	let info = disk.checkSync(path);
-	console.log(info.available);
-	console.log(info.free);
-	console.log(info.total);
+  let info = disk.checkSync(path);
+  console.log(info.available);
+  console.log(info.free);
+  console.log(info.total);
 }
 catch (err) {
-	console.log(err);
+  console.log(err);
 }
 ```
 
@@ -66,5 +87,17 @@ type DiskUsage = {
 }
 
 export function check(path: string, callback: (error: Error, result: DiskUsage) => void): void;
+export function check(path: string): Promise<DiskUsage>
 export function checkSync(path: string): DiskUsage;
+```
+
+Demo
+----
+
+To see a demo of this library see the `demo/` folder.
+
+You can run it with node: (node 8+ required)
+
+```bash
+node ./demo/
 ```

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,0 +1,44 @@
+const { check, checkSync } = require("../");
+const os = require("os");
+
+const targetPath = os.platform() === "win32" ? "c:" : "/";
+
+function printResults(type, { available, free, local }) {
+  console.log(`${type}
+    Available: ${available}
+    Free: ${free}
+    Local: ${local}
+  `);
+}
+
+async function getFreeSpacePromise(path) {
+  try {
+    const info = await check(path);
+    printResults("PROMISE", info);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function getFreeSpaceCallback(path) {
+  check(path, (err, info) => {
+    if (err) {
+      console.error(err);
+    } else {
+      printResults("CALLBACK", info);
+    }
+  });
+}
+
+function getFreeSpaceSync(path) {
+  const info = checkSync(path);
+  printResults("SYNC", info);
+}
+
+async function start() {
+  await getFreeSpacePromise(targetPath);
+  getFreeSpaceCallback(targetPath);
+  getFreeSpaceSync(targetPath);
+}
+
+start()

--- a/demo/index.js
+++ b/demo/index.js
@@ -3,11 +3,11 @@ const os = require("os");
 
 const targetPath = os.platform() === "win32" ? "c:" : "/";
 
-function printResults(type, { available, free, local }) {
+function printResults(type, { available, free, total }) {
   console.log(`${type}
     Available: ${available}
     Free: ${free}
-    Local: ${local}
+    Tocal: ${total}
   `);
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,4 +5,5 @@ type DiskUsage = {
 }
 
 export function check(path: string, callback: (error: Error, result: DiskUsage) => void): void;
+export function check(path: string): Promise<DiskUsage>
 export function checkSync(path: string): DiskUsage;

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var native = require("./build/Release/diskusage.node");
+var promise = typeof Promise !== "undefined" ? Promise : require("es6-promise").Promise
 
 exports.check = function(path, callback) {
   if (callback) {
     return check(path, callback);
   }
 
-  return new Promise(function (resolve, reject) {
+  return new promise(function (resolve, reject) {
       check(path, function (err, result) {
           err ? reject(err) : resolve(result)
       })

--- a/index.js
+++ b/index.js
@@ -1,15 +1,28 @@
-var native = require('./build/Release/diskusage.node');
+var native = require("./build/Release/diskusage.node");
 
 exports.check = function(path, callback) {
-    var result = undefined;
-    var error = undefined;
-    try {
-        result = native.getDiskUsage(path);
-    }
-    catch (error_) {
-        error = error_
-    }
-    callback(error, result);
+  if (callback) {
+    return check(path, callback);
+  }
+
+  return new Promise(function (resolve, reject) {
+      check(path, function (err, result) {
+          err ? reject(err) : resolve(result)
+      })
+  })
 };
 
 exports.checkSync = native.getDiskUsage;
+
+function check(path, callback) {
+  var result = undefined;
+  var error = undefined;
+
+  try {
+    result = native.getDiskUsage(path);
+  } catch (error_) {
+    error = error_;
+  }
+
+  callback(error, result);
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "typings": "index.d.ts",
   "gypfile": true,
   "dependencies": {
+    "es6-promise": "^4.2.5",
     "nan": "^2.11.1"
   },
   "repository": {


### PR DESCRIPTION
This PR will add `Promise` support for the async call.  If a callback is **not** supplied, then the `check` function will return a `Promise<DiskUsage>` instead.  Allowing for the use of `async/await`, or regular promise handling.

I did not use ES6 style syntax for the modifications, but if wanted I can convert it to the newer syntax.

I have also updated the Typescript typings, the README and added a demo file showcasing the different ways of using this library.