### PR TITLE
Works with clang Apple LLVM version 10.0.0 (Xcode 10)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -36,7 +36,8 @@
         }],
         ['OS=="mac"', {
           'xcode_settings': {
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++'
           }
         }]
       ]


### PR DESCRIPTION
After upgrading to Xcode 10, I can't  install `diskusage`. It looks like specifying the C++ library solves it.