### PR TITLE
fix: support Node 12 / Electron 5

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ static NAN_METHOD(GetDiskUsage)
     }
 }
 
-void Init(v8::Handle<v8::Object> exports)
+void Init(v8::Local<v8::Object> exports)
 {
     Nan::SetMethod(exports, "getDiskUsage", GetDiskUsage);
 }


### PR DESCRIPTION
Ref: https://github.com/jduncanator/node-diskusage/issues/17#issuecomment-480892798

Replace `v8::Handle` with `v8::Local`
This should not affect behavior in any way since `Handle` was an alias for `Local`.

From [v8docs.nodesource.com](https://v8docs.nodesource.com/node-10.6/d4/da0/v8_8h_source.html#l00342):
```c++
#if !defined(V8_IMMINENT_DEPRECATION_WARNINGS)
// Handle is an alias for Local for historical reasons.
template <class T>
using Handle = Local<T>;
#endif
```

See also:

* https://electronjs.org/blog/nodejs-native-addons-and-electron-5
* https://codereview.chromium.org/1224623004
* https://v8docs.nodesource.com/node-10.6/d2/dc3/namespacev8.html#a569580ff6260b59779fb214d5a1448fd