### PR TITLE
fix: use Nan::Utf8String instead of v8::String::Utf8Value (fixes #37)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ static NAN_METHOD(GetDiskUsage)
     Nan::HandleScope scope;
 
     try {
-        DiskUsage result = GetDiskUsage(*v8::String::Utf8Value(info[0]));
+        DiskUsage result = GetDiskUsage(*Nan::Utf8String(info[0]));
         info.GetReturnValue().Set(ConvertDiskUsage(result));
     }
     catch (const SystemError &error) {


### PR DESCRIPTION
It looks like using `Nan::Utf8String` instead of `v8::String::Utf8Value` like we did on [`node-serialport`/#1843](https://github.com/node-serialport/node-serialport/pull/1843/files) will fix #37 (and hopefully not break anything in the process).

```
node_modules\diskusage\src\main.cpp(26): error C2440: '<function-style-cast>': cannot convert from 'v8::Local<v8::Value>' to 'v8::String::Utf8Value' [C:\Users\User\Documents\tmp\node_modules\diskusage\build\diskusage.vcxproj]
  c:\users\User\documents\tmp\node_modules\diskusage\src\main.cpp(26): note: No constructor could take the source type, or constructor overload resolution was ambiguous
```