### PR TITLE
Kill warnings when building for node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "gypfile": true,
   "dependencies": {
     "es6-promise": "^4.2.5",
-    "nan": "^2.13.2"
+    "nan": "^2.14.0"
   },
   "devDependencies": {
     "eslint": "^6.0.1"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,9 @@
 static v8::Local<v8::Object> ConvertDiskUsage(const DiskUsage& usage)
 {
     v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-    obj->Set(Nan::New<v8::String>("available").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(usage.available)));
-    obj->Set(Nan::New<v8::String>("free").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(usage.free)));
-    obj->Set(Nan::New<v8::String>("total").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(usage.total)));
+    Nan::Set(obj, Nan::New<v8::String>("available").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(usage.available)));
+    Nan::Set(obj, Nan::New<v8::String>("free").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(usage.free)));
+    Nan::Set(obj, Nan::New<v8::String>("total").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(usage.total)));
 
     return obj;
 }


### PR DESCRIPTION
By updating Nan and a minor change, node 12 support is added.

Tested locally on macOS with node 8.11.3 and node 12.1.0.