### PR TITLE
fix spread operator on promise await example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ disk.check(path, function(err, info) {
 // Promise
 async function getFreeSpace(path) {
   try {
-    const { free } = await disk.check(path);
+    const  {...free}  = await disk.check(path);
     console.log(`Free space: ${free}`);
     return free
   } catch (err) {


### PR DESCRIPTION
const  {free}  = await disk.check(path); returns undefined in node 12.16.3, returns correct key/value when spread operator is applied.