### PR TITLE
Make module context-aware in Node 10+

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,9 +34,13 @@ static NAN_METHOD(GetDiskUsage)
     }
 }
 
-void Init(v8::Local<v8::Object> exports)
+NAN_MODULE_INIT(Init)
 {
-    Nan::SetMethod(exports, "getDiskUsage", GetDiskUsage);
+    Nan::SetMethod(target, "getDiskUsage", GetDiskUsage);
 }
 
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(diskusage, Init)
+#else
 NODE_MODULE(diskusage, Init)
+#endif


### PR DESCRIPTION
It is no longer possible to use this module in newer versions of Electron due to native modules being required to be context aware. The ability to disable this requirement (which is deprecated since Electron 10), is removed in the next version (14). See: https://github.com/electron/electron/issues/18397

Luckily, it is rather easy to use NAN to make the module context aware, if the Node version is high enough to support it. This change allows this module to be used on older and newer versions of Electron and Node.