### PR TITLE
fix: Resolve dependency issues on Node.js 20

### DIFF
--- a/fallback.js
+++ b/fallback.js
@@ -1,0 +1,29 @@
+var native = require("./build/Release/diskusage.node");
+var promise = typeof Promise !== "undefined" ? Promise : require("es6-promise").Promise;
+
+exports.check = function(path, callback) {
+  if (callback) {
+    return check(path, callback);
+  }
+
+  return new promise(function (resolve, reject) {
+    check(path, function (err, result) {
+      err ? reject(err) : resolve(result);
+    });
+  });
+};
+
+exports.checkSync = native.getDiskUsage;
+
+function check(path, callback) {
+  var result = undefined;
+  var error = undefined;
+
+  try {
+    result = native.getDiskUsage(path);
+  } catch (error_) {
+    error = error_;
+  }
+
+  callback(error, result);
+}

--- a/index.js
+++ b/index.js
@@ -30,23 +30,14 @@ if(typeof fs.statfs === 'function') {
     });
   }
 
-  exports.checkSync = function(path, callback) {
-    var result = undefined;
-    var error = undefined;
-  
-    try {
-      var result_ = fs.statfsSync(path);
+  exports.checkSync = function(path) {
+    var result = fs.statfsSync(path);
 
-      result = {
-        available: result_.bavail * result_.bsize,
-        free: result_.bfree * result_.bsize,
-        total: result_.blocks * result_.bsize
-      }
-    } catch(error_) {
-      error = error_;
+    return {
+      available: result.bavail * result.bsize,
+      free: result.bfree * result.bsize,
+      total: result.blocks * result.bsize
     }
-
-    callback(error, result);
   }
 } else {
   var diskusage = require('./fallback.js');

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "typings": "index.d.ts",
   "gypfile": true,
   "dependencies": {
-    "es6-promise": "^4.2.5",
-    "nan": "^2.14.0"
+    "es6-promise": "^4.2.8",
+    "nan": "^2.18.0"
   },
   "devDependencies": {
-    "eslint": "^6.0.1"
+    "eslint": "^8.49.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This bumps dependencies to resolve installation issues with Node 20. It also drops the native module and makes use of `fs.statfs` where available (Node.js >=18).

Ideally we wouldn't require `node-gyp`, or the native module at all when installing under supported engines, but there doesn't seem to be an elegant way to achieve that, and I don't want to drop support for Node <18 (yet).

This supersedes #61, and should resolve #60 and #59.  @francois-spectre and @radjybaba, testing would be appreciated to confirm this fixes your issues!

Resisting the urge to type `const`, use object destructuring, and lambdas whilst making this change was very hard... it hurts my eyes (and my soul).